### PR TITLE
package: add missing icons, support ligature

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   "author": "Dalci de Jesus Bagolin <dalci.b+npm@gmail.com> (https://github.org/dalcib)",
   "license": "MIT",
   "dependencies": {
-    "@mdi/svg": "5.3.45",
-    "webfont": "^9.0.0"
+    "@mdi/svg": "6.6.96",
+    "webfont": "^11.3.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "@mdi/svg": "6.6.96",
-    "webfont": "^11.3.0"
+    "webfont": "^11.2.26"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Material Icons font supports ligatures by default - 
given some `<mat-icon>add</mat-icon>` it knows to get the correct icon, without a need for the json mapping.

I would like to use this repository as a drop in replacement for the material font, so I wish for it to ideally support exactly what material does.

(upgrade is needed due to https://github.com/itgalaxy/webfont/issues/174 and https://github.com/itgalaxy/webfont/issues/457)